### PR TITLE
Fix for `block_num != 0`

### DIFF
--- a/libraries/app/application.cpp
+++ b/libraries/app/application.cpp
@@ -801,6 +801,9 @@ namespace detail {
             if (high_block_num == 0)
               return synopsis; // we have no blocks
           }
+          
+          if( low_block_num == 0)
+             low_block_num = 1;
 
           // at this point:
           // low_block_num is the block before the first block we can undo, 


### PR DESCRIPTION
Backport from Steem/BitShares
Some info here: https://github.com/bitshares/bitshares-core/issues/273