### PR TITLE
Fix clear_expired_transactions memory leak

### DIFF
--- a/libraries/chain/db_update.cpp
+++ b/libraries/chain/db_update.cpp
@@ -184,8 +184,8 @@ void database::clear_expired_transactions()
    //Transactions must have expired by at least two forking windows in order to be removed.
    auto& transaction_idx = static_cast<transaction_index&>(get_mutable_index(implementation_ids, impl_transaction_object_type));
    const auto& dedupe_index = transaction_idx.indices().get<by_expiration>();
-   while( (!dedupe_index.empty()) && (head_block_time() > dedupe_index.rbegin()->trx.expiration) )
-      transaction_idx.remove(*dedupe_index.rbegin());
+   while( (!dedupe_index.empty()) && (head_block_time() > dedupe_index.begin()->trx.expiration) )
+      transaction_idx.remove(*dedupe_index.begin());
 } FC_CAPTURE_AND_RETHROW() }
 
 void database::clear_expired_proposals()


### PR DESCRIPTION
Backport from Steem/BitShares: https://github.com/bitshares/bitshares-core/issues/256