### PR TITLE
feature/rework duplicate operation check

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "docs"]
-	path = docs
-	url = https://github.com/cryptonomex/graphene.wiki.git
+    path = docs
+    url = https://github.com/bitshares/bitshares-core.wiki.git
     ignore = dirty
 [submodule "libraries/fc"]
-	path = libraries/fc
-	url = https://github.com/PBSA/peerplays-0.1-fc.git
+    path = libraries/fc
+    url = https://github.com/PBSA/peerplays-fc.git
     ignore = dirty

--- a/libraries/chain/db_block.cpp
+++ b/libraries/chain/db_block.cpp
@@ -154,16 +154,8 @@ void database::check_tansaction_for_duplicated_operations(const signed_transacti
    const auto& proposal_index = get_index<proposal_object>();
    std::set<fc::sha256> existed_operations_digests;
    
-   //operation create_betting_market_group_op( create_betting_market_group_operation() );
-   //operation create_betting_market_op( create_betting_market_operation() );
-
    proposal_index.inspect_all_objects( [&](const object& obj){
       const proposal_object& proposal = static_cast<const proposal_object&>(obj);
-      //for (auto& operation: proposal.proposed_transaction.operations)
-      //{
-      //   if( !(operation == create_betting_market_group_op) && !(operation == create_betting_market_op) ) 
-      //      existed_operations_digests.insert(fc::digest(operation));
-      //}
       auto proposed_operations_digests = gather_proposed_operations_digests( proposal.proposed_transaction );
       existed_operations_digests.insert( proposed_operations_digests.begin(), proposed_operations_digests.end() );
    });

--- a/tests/common/database_fixture.cpp
+++ b/tests/common/database_fixture.cpp
@@ -59,7 +59,7 @@
 
 using namespace graphene::chain::test;
 
-uint32_t GRAPHENE_TESTING_GENESIS_TIMESTAMP = 1431700000;
+uint32_t GRAPHENE_TESTING_GENESIS_TIMESTAMP = 1431700002;
 
 namespace graphene { namespace chain {
 


### PR DESCRIPTION
Duplicate operation check reworked in way that no exceptions are thrown when there are events with the same betting_market_group and/or the same betting_market
