### PR TITLE
Make indexes on blockchain objects related to betting markets into

### DIFF
--- a/libraries/chain/include/graphene/chain/betting_market_object.hpp
+++ b/libraries/chain/include/graphene/chain/betting_market_object.hpp
@@ -247,8 +247,12 @@ typedef multi_index_container<
    betting_market_group_object,
    indexed_by<
       ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
-      ordered_non_unique< tag<by_event_id>, member<betting_market_group_object, event_id_type, &betting_market_group_object::event_id> >,
-      ordered_non_unique< tag<by_settling_time>, member<betting_market_group_object, fc::optional<fc::time_point_sec>, &betting_market_group_object::settling_time> >
+      ordered_unique< tag<by_event_id>, composite_key<betting_market_group_object,
+                                                      member<betting_market_group_object, event_id_type, &betting_market_group_object::event_id>,
+                                                      member<object, object_id_type, &object::id> > >,
+      ordered_unique< tag<by_settling_time>, composite_key<betting_market_group_object,
+                                                           member<betting_market_group_object, fc::optional<fc::time_point_sec>, &betting_market_group_object::settling_time>,
+                                                           member<object, object_id_type, &object::id> > >
    > > betting_market_group_object_multi_index_type;
 typedef generic_index<betting_market_group_object, betting_market_group_object_multi_index_type> betting_market_group_object_index;
 
@@ -256,7 +260,9 @@ typedef multi_index_container<
    betting_market_object,
    indexed_by<
       ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
-      ordered_non_unique< tag<by_betting_market_group_id>, member<betting_market_object, betting_market_group_id_type, &betting_market_object::group_id> >
+      ordered_unique< tag<by_betting_market_group_id>, composite_key<betting_market_object,
+                                                                     member<betting_market_object, betting_market_group_id_type, &betting_market_object::group_id>,
+                                                                     member<object, object_id_type, &object::id> > >
    > > betting_market_object_multi_index_type;
 
 typedef generic_index<betting_market_object, betting_market_object_multi_index_type> betting_market_object_index;
@@ -593,7 +599,9 @@ typedef multi_index_container<
    indexed_by<
       ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
       ordered_unique< tag<by_odds>, identity<bet_object>, compare_bet_by_odds >,
-      ordered_non_unique< tag<by_betting_market_id>, member<bet_object, betting_market_id_type, &bet_object::betting_market_id> >,
+      ordered_unique< tag<by_betting_market_id>, composite_key<bet_object,
+                                                                   member<bet_object, betting_market_id_type, &bet_object::betting_market_id>,
+                                                                   member<object, object_id_type, &object::id> > >,
       ordered_unique< tag<by_bettor_and_odds>, identity<bet_object>, compare_bet_by_bettor_then_odds > > > bet_object_multi_index_type;
 typedef generic_index<bet_object, bet_object_multi_index_type> bet_object_index;
 

--- a/libraries/chain/include/graphene/chain/config.hpp
+++ b/libraries/chain/include/graphene/chain/config.hpp
@@ -151,7 +151,7 @@
 #define GRAPHENE_RECENTLY_MISSED_COUNT_INCREMENT             4
 #define GRAPHENE_RECENTLY_MISSED_COUNT_DECREMENT             3
 
-#define GRAPHENE_CURRENT_DB_VERSION                          "PPY2.0"
+#define GRAPHENE_CURRENT_DB_VERSION                          "PPY2.1"
 
 #define GRAPHENE_IRREVERSIBLE_THRESHOLD                      (70 * GRAPHENE_1_PERCENT)
 

--- a/libraries/chain/include/graphene/chain/event_group_object.hpp
+++ b/libraries/chain/include/graphene/chain/event_group_object.hpp
@@ -27,6 +27,8 @@
 #include <graphene/db/object.hpp>
 #include <graphene/db/generic_index.hpp>
 
+#include <boost/multi_index/composite_key.hpp>
+
 namespace graphene { namespace chain {
 
 class database;
@@ -49,7 +51,9 @@ typedef multi_index_container<
    event_group_object,
    indexed_by<
       ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >, 
-      ordered_non_unique< tag<by_sport_id>, member< event_group_object, sport_id_type, &event_group_object::sport_id > >      >
+      ordered_unique< tag<by_sport_id>, composite_key<event_group_object,
+                                                      member< event_group_object, sport_id_type, &event_group_object::sport_id >,
+                                                      member<object, object_id_type, &object::id> > > >
    > event_group_object_multi_index_type;
 
 typedef generic_index<event_group_object, event_group_object_multi_index_type> event_group_object_index;

--- a/libraries/chain/include/graphene/chain/event_object.hpp
+++ b/libraries/chain/include/graphene/chain/event_object.hpp
@@ -28,6 +28,8 @@
 #include <graphene/db/generic_index.hpp>
 #include <graphene/chain/protocol/event.hpp>
 
+#include <boost/multi_index/composite_key.hpp>
+
 namespace graphene { namespace chain {
    class event_object;
 } }
@@ -100,8 +102,12 @@ typedef multi_index_container<
    event_object,
    indexed_by<
       ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
-      ordered_non_unique< tag<by_event_group_id>, member< event_object, event_group_id_type, &event_object::event_group_id > >,
-      ordered_non_unique< tag<by_event_status>, const_mem_fun< event_object, event_status, &event_object::get_status > > > > event_object_multi_index_type;
+      ordered_unique< tag<by_event_group_id>, composite_key<event_object,
+                                                            member< event_object, event_group_id_type, &event_object::event_group_id >,
+                                                            member<object, object_id_type, &object::id> > >,
+      ordered_unique< tag<by_event_status>, composite_key<event_object,
+                                                          const_mem_fun< event_object, event_status, &event_object::get_status >,
+                                                          member<object, object_id_type, &object::id> > > > > event_object_multi_index_type;
 
 typedef generic_index<event_object, event_object_multi_index_type> event_object_index;
 

--- a/libraries/chain/include/graphene/chain/tournament_object.hpp
+++ b/libraries/chain/include/graphene/chain/tournament_object.hpp
@@ -133,14 +133,16 @@ namespace graphene { namespace chain {
       tournament_object,
       indexed_by<
          ordered_unique< tag<by_id>, member< object, object_id_type, &object::id > >,
-         ordered_non_unique< tag<by_registration_deadline>, 
+         ordered_unique< tag<by_registration_deadline>, 
             composite_key<tournament_object, 
                const_mem_fun<tournament_object, tournament_state, &tournament_object::get_state>, 
-               const_mem_fun<tournament_object, time_point_sec, &tournament_object::get_registration_deadline> > >,
-         ordered_non_unique< tag<by_start_time>, 
+               const_mem_fun<tournament_object, time_point_sec, &tournament_object::get_registration_deadline>,
+               member< object, object_id_type, &object::id > > >,
+         ordered_unique< tag<by_start_time>, 
             composite_key<tournament_object, 
                const_mem_fun<tournament_object, tournament_state, &tournament_object::get_state>, 
-               member<tournament_object, optional<time_point_sec>, &tournament_object::start_time> > >
+               member<tournament_object, optional<time_point_sec>, &tournament_object::start_time>,
+               member< object, object_id_type, &object::id > > >
       >
    > tournament_object_multi_index_type;
    typedef generic_index<tournament_object, tournament_object_multi_index_type> tournament_index;


### PR DESCRIPTION
This fixes a bug that showed up when multiple betting market groups were resolved in one block.  non_unique indexes were used, which allowed different nodes to resolve the betting market groups in different orders.  This also caused nodes to assign different operation ids to the resolution objects on different nodes.  This is fixed by making the bmg-related indexes unique, so when multiple bmgs are resolved in a single block, they will always be processed in order of their bmg id.